### PR TITLE
Fix broken layout in Acerca de view

### DIFF
--- a/_harp/acerca.ejs
+++ b/_harp/acerca.ejs
@@ -43,12 +43,11 @@
      
       <div class="row">
         <% var team = public._data.team  %>
-        <% var cols = 12 / team.length  %>
+        <% var cols = Math.floor(12 / team.length)  %>
         <% for(var i = 0; i < team.length; i++) { %>
           <% var username = team[i] %>
           <% var member = public.posts._data.authors[username] %>
-
-            <div class="col-md-<%= cols %>">
+            <div class="col-md-<%= cols %>"i style="width: 20%;">
               <img alt="team image" class="img-responsive" src="<%= member.avatar %>?s=200">
               <div class="team-info text-center">
                 <h4><%= member.name %></h4>


### PR DESCRIPTION
@julianduque @edsadr @academo The reason why the layout was broken is because 12(cols) / 5 (us) = 2.4, so the class col-md-2.4 doesn't exist. I rounded down to col-md-2 but that will be 16.6666% width space for each of us. 

Anyway, I hardcoded the width: 20% inline style css (I saw other places in the code that did so), but obviously it will break the layout again when we add another team member. My question is do we leave it as it is? Should I add logic in the view to that math? What do you guys think?