### PR TITLE
Delete the anchor to open a modal

### DIFF
--- a/components/AppHeroes.vue
+++ b/components/AppHeroes.vue
@@ -12,11 +12,11 @@
       <div class="row">
         <div class="col-md-10 col-md-offset-1">
           <div id="heroes" class="heroes">
-            <div class="col-lg-3 col-md-3 col-sm-4 col-xs-12 profileHero" v-for="hero in heroes">
-              <div class="img-box reviewer-mock" v-b-modal="'modal-' + hero.username">
-                <img v-bind:src="hero.avatar" class="img-responsive">
+            <div class="col-lg-3 col-md-3 col-sm-4 col-xs-12 profileHero" v-for="(hero, key) in heroes" :key="key">
+              <div class="img-box reviewer-mock">
+                <img :src="hero.avatar" class="img-responsive">
                 <ul class="text-center hidden-sm hidden-xs">
-                   <a target="_blank" v-bind:href="hero.github"><i class="fa fa-github"></i></a>
+                   <a target="_blank" :href="hero.github"><i class="fa fa-github"></i></a>
                    <a target="_blank" :href="hero.twitter"><i class="fa fa-twitter"></i></a>
                    <a v-b-modal="'modal-' + hero.username"><i class="fa fa-comment"></i></a>
                 </ul>
@@ -24,25 +24,11 @@
               <div class="text-center ">
                 <h1>{{hero.name}}</h1>
                 <div class="member-connections hidden-lg hidden-md">
-                  <a target="_blank" v-bind:href="hero.github"><i class="fa fa-github"></i></a>
+                  <a target="_blank" :href="hero.github"><i class="fa fa-github"></i></a>
                   <a target="_blank" :href="hero.twitter"><i class="fa fa-twitter"></i></a>
                   <a v-b-modal="'modal-' + hero.username"><i class="fa fa-comment"></i></a>
                 </div>
               </div>
-
-              <b-modal size="lg" hide-footer v-bind:id="'modal-' +hero.username" :title="'Charlas de '+hero.name">
-                <ul class="timeline">
-                  <li v-for="slide in hero.slides">
-                    <div :class="'direction-'+slide.direction">
-                      <div class="flag-wrapper">
-                        <span class="flag">{{slide.title}}</span>
-                        <!-- <span class="time-wrapper"><span class="time">fecha</span></span> -->
-                      </div>
-                      <div class="desc"><a :href="slide.url">{{slide.url}}</a></div>
-                    </div>
-                  </li>
-                </ul>
-              </b-modal>
             </div>
           </div>
         </div>

--- a/components/AppHeroes.vue
+++ b/components/AppHeroes.vue
@@ -18,7 +18,7 @@
                 <ul class="text-center hidden-sm hidden-xs">
                    <a target="_blank" :href="hero.github"><i class="fa fa-github"></i></a>
                    <a target="_blank" :href="hero.twitter"><i class="fa fa-twitter"></i></a>
-                   <a v-b-modal="'modal-' + hero.username"><i class="fa fa-comment"></i></a>
+                   <a @click="$modal.show(hero.username)"><i class="fa fa-comment"></i></a>
                 </ul>
               </div>
               <div class="text-center ">
@@ -26,9 +26,21 @@
                 <div class="member-connections hidden-lg hidden-md">
                   <a target="_blank" :href="hero.github"><i class="fa fa-github"></i></a>
                   <a target="_blank" :href="hero.twitter"><i class="fa fa-twitter"></i></a>
-                  <a v-b-modal="'modal-' + hero.username"><i class="fa fa-comment"></i></a>
+                  <a @click="$modal.show(hero.username)"><i class="fa fa-comment"></i></a>
                 </div>
               </div>
+              <modal :name="hero.username" :width="700" :height="700">
+                <ul class="timeline" v-if="hero">
+                  <li v-for="(slide, index) in hero.slides" :key="index">
+                    <div :class="'direction-'+slide.direction">
+                      <div class="flag-wrapper">
+                        <span class="flag">{{slide.title}}</span>
+                      </div>
+                      <div class="desc"><a :href="slide.url">{{slide.url}}</a></div>
+                    </div>
+                  </li>
+                </ul>
+              </modal>
             </div>
           </div>
         </div>
@@ -39,12 +51,80 @@
 
 
 <script>
-import heroes from '@/assets/data/heroes.js'
-export default{
-  data () {
-    return {
-      heroes
+  import heroes from '@/assets/data/heroes.js'
+  export default {
+    data () {
+      return {
+        heroes,
+        showModal: false
+      }
     }
   }
-}
 </script>
+
+
+<style scoped>
+.modal-mask {
+  position: fixed;
+  z-index: 9998;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, .5);
+  display: table;
+  transition: opacity .3s ease;
+}
+
+.modal-wrapper {
+  display: table-cell;
+  vertical-align: middle;
+}
+
+.modal-container {
+  width: 300px;
+  margin: 0px auto;
+  padding: 20px 30px;
+  background-color: #fff;
+  border-radius: 2px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, .33);
+  transition: all .3s ease;
+  font-family: Helvetica, Arial, sans-serif;
+}
+
+.modal-header h3 {
+  margin-top: 0;
+  color: #42b983;
+}
+
+.modal-body {
+  margin: 20px 0;
+}
+
+.modal-default-button {
+  float: right;
+}
+
+/*
+ * The following styles are auto-applied to elements with
+ * transition="modal" when their visibility is toggled
+ * by Vue.js.
+ *
+ * You can easily play with the modal transition by editing
+ * these styles.
+ */
+
+.modal-enter {
+  opacity: 0;
+}
+
+.modal-leave-active {
+  opacity: 0;
+}
+
+.modal-enter .modal-container,
+.modal-leave-active .modal-container {
+  -webkit-transform: scale(1.1);
+  transform: scale(1.1);
+}
+</style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -2,7 +2,7 @@ const routerBase = process.env.DEPLOY_ENV === 'GH_PAGES' ? {
   router: {
     base: '/medellinjs/'
   }
-} : {};
+} : {}
 
 module.exports = {
   /*
@@ -36,6 +36,8 @@ module.exports = {
     'bootstrap-vue/nuxt',
     '@nuxtjs/font-awesome'
   ],
+
+  plugins: ['~/plugins/vue-js-modal'],
   /*
   ** Customize the progress bar color
   */

--- a/package-lock.json
+++ b/package-lock.json
@@ -9849,6 +9849,11 @@
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.2.4.tgz",
       "integrity": "sha512-e+ThJMYmZg4D9UnrLcr6LQxGu6YlcxkrmZGPCyIN4malcNhdeGGKxmFuM5y6ICMJJxQywLfT8MM1rYZr4LpeLw=="
     },
+    "vue-js-modal": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/vue-js-modal/-/vue-js-modal-1.3.12.tgz",
+      "integrity": "sha512-mT/RzGa1n63XoQ60L5JO6jFXG7A0Tmdk7n+5w7L33PtxcwtYV6gkasW29JTWA02Ifddmii+ZW4jcXmxgXcBbKw=="
+    },
     "vue-loader": {
       "version": "13.6.2",
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-13.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "animate.css": "^3.5.2",
     "bootstrap": "^3.3.7",
     "bootstrap-vue": "^1.4.0",
-    "nuxt": "^1.0.0-rc11"
+    "nuxt": "^1.0.0-rc11",
+    "vue-js-modal": "^1.3.12"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",

--- a/plugins/vue-js-modal.js
+++ b/plugins/vue-js-modal.js
@@ -1,0 +1,4 @@
+import Vue from 'vue'
+import VModal from 'vue-js-modal/dist/ssr.index'
+
+Vue.use(VModal)


### PR DESCRIPTION
Fix:

- Delete the anchor to open a modal, _an invisible modal is currently being opened every time a hero is clicked and this means that clicking on the navbar is not allowed_