### PR TITLE
Arregla #256 - Alinear footer en la sección de Héroes

### DIFF
--- a/components/AppHeroes.vue
+++ b/components/AppHeroes.vue
@@ -105,6 +105,15 @@
   float: right;
 }
 
+ul.rs-links {
+  bottom: 30%; /* Reset style */
+  letter-spacing: 0; /* Reset style */
+}
+
+ul.rs-links a {
+  margin: 0 5px;
+}
+
 /*
  * The following styles are auto-applied to elements with
  * transition="modal" when their visibility is toggled

--- a/components/AppHeroes.vue
+++ b/components/AppHeroes.vue
@@ -96,11 +96,6 @@
   margin-top: 0;
   color: #42b983;
 }
-ul.rs-links{
-  top: 44%;
-  bottom: unset;
-  padding-left: 9px;
-}
 
 .modal-body {
   margin: 20px 0;

--- a/components/AppHeroes.vue
+++ b/components/AppHeroes.vue
@@ -111,6 +111,7 @@ ul.rs-links {
 }
 
 ul.rs-links a {
+  cursor: pointer;
   margin: 0 5px;
 }
 

--- a/components/AppHeroes.vue
+++ b/components/AppHeroes.vue
@@ -107,12 +107,15 @@
 
 ul.rs-links {
   bottom: 30%; /* Reset style */
-  letter-spacing: 0; /* Reset style */
 }
 
 ul.rs-links a {
   cursor: pointer;
   margin: 0 5px;
+}
+
+ul.rs-links i {
+  letter-spacing: 0; /* Reset style */
 }
 
 /*


### PR DESCRIPTION
Este alinea las redes sociales del héroe en la parte inferior de la imagen (#256), igualmente arregla el centrado de los iconos que estaban a la izquierda por el letter-spacing y en su lugar se utiliza un margin de 5px a los lados.

**Resultado final:**
![image](https://user-images.githubusercontent.com/2999604/52904468-b92f9880-31fa-11e9-8461-5a67d918d13e.png)
