### PR TITLE
Use SSL to load image from Gravatar

### DIFF
--- a/assets/data/heroes.js
+++ b/assets/data/heroes.js
@@ -589,7 +589,7 @@ module.exports = {
     username: 'alexav',
     twitter: 'https://twitter.com/alexav',
     github: 'https://github.com/axelavargas',
-    avatar: 'http://www.gravatar.com/avatar/e322c4c78b001b013477ef504c1507b3.jpg?s=200',
+    avatar: 'https://www.gravatar.com/avatar/e322c4c78b001b013477ef504c1507b3.jpg?s=200',
     slides: [
       {
         direction: 'r',


### PR DESCRIPTION
# Pull request

Closes #314 

## Observaciones

Había un avatar en la sección de "Héroes" cargándose por medio de HTTP en lugar de usar HTTPS y por lo tanto el navegador mostraba que la conexión a la página no era "totalmente segura".