### PR TITLE
328 - Navigation whitespace

### DIFF
--- a/assets/scss/responsive.scss
+++ b/assets/scss/responsive.scss
@@ -1,5 +1,8 @@
 /* Navigation */
-@media screen and (min-width: 769px){
+@media screen and (min-width: 768px){
+  .navbar {
+    font-size: 0;
+  }
   .navbar-default .navbar-collapse {
     display: inline-block !important;
     padding: 0;
@@ -21,7 +24,7 @@
   }
   .navbar-default .nav-download a{
     padding: 10px !important;
-    margin: 11px;
+    margin: 10px;
   }
 }
 @media screen and (min-width: 992px){


### PR DESCRIPTION
# Pull request

Closes #328

## Observaciones

_font-size: 0;_ utilizado para eliminar el espacio en blanco entre inline blocks, mencionado en el siguiente artóculo: https://css-tricks.com/fighting-the-space-between-inline-block-elements/
