### PR TITLE
Arreglar issue #532

### DIFF
--- a/components/AppShortHeroes.vue
+++ b/components/AppShortHeroes.vue
@@ -42,14 +42,17 @@ export default {
     return {
       keysHeros: Object.keys(heroesData),
       showModal: false,
+      myHeroes: [],
     }
   },
   computed: {
     heroes() {
-      const heoresKeys = sampleSize(this.keysHeros, 8)
-      const heroes = heoresKeys.map((heroe) => heroesData[heroe])
-      return heroes
+      return this.myHeroes
     },
+  },
+  mounted() {
+    const heoresKeys = sampleSize(this.keysHeros, 8)
+    this.myHeroes = heoresKeys.map((heroe) => heroesData[heroe])
   },
 }
 </script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -8,7 +8,7 @@ const routerBase =
     : {}
 
 export default {
-  mode: 'universal',
+  ssr: true,
   /*
    ** Headers of the page
    */


### PR DESCRIPTION
# Arreglar seccion de Heroes

Closes #(532)

## Overview

Actualmente, en la seccion de heroes, hay un side effect cuando se renderiza con `SSR`. Entonce se movio esa carga para que solo cargue en el `client side` 

## Preview URL
[Deploy preview ###](https://deploy-preview-###--medellinjs.netlify.com/)

*Please change the ### for the number of the `pull request`, after that you can delete this line*.
