### PR TITLE
redirect 404 page

### DIFF
--- a/components/AppShortHeroes.vue
+++ b/components/AppShortHeroes.vue
@@ -50,7 +50,7 @@ export default {
       return this.myHeroes
     },
   },
-  mounted() {
+  created() {
     const heroesKeys = sampleSize(this.keysHeros, 8)
     this.myHeroes = heroesKeys.map((hero) => heroesData[hero])
   },

--- a/components/AppShortHeroes.vue
+++ b/components/AppShortHeroes.vue
@@ -51,8 +51,8 @@ export default {
     },
   },
   mounted() {
-    const heoresKeys = sampleSize(this.keysHeros, 8)
-    this.myHeroes = heoresKeys.map((heroe) => heroesData[heroe])
+    const heroesKeys = sampleSize(this.keysHeros, 8)
+    this.myHeroes = heroesKeys.map((hero) => heroesData[hero])
   },
 }
 </script>

--- a/components/AppShortHeroes.vue
+++ b/components/AppShortHeroes.vue
@@ -42,14 +42,17 @@ export default {
     return {
       keysHeros: Object.keys(heroesData),
       showModal: false,
+      myHeroes: [],
     }
   },
   computed: {
     heroes() {
-      const heoresKeys = sampleSize(this.keysHeros, 8)
-      const heroes = heoresKeys.map((heroe) => heroesData[heroe])
-      return heroes
+      return this.myHeroes
     },
+  },
+  mounted() {
+    const heoresKeys = sampleSize(this.keysHeros, 8)
+    this.myHeroes = heoresKeys.map((heroe) => heroesData[heroe])
   },
 }
 </script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -8,7 +8,7 @@ const routerBase =
     : {}
 
 export default {
-  mode: 'universal',
+  ssr: true,
   /*
    ** Headers of the page
    */

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -3,9 +3,26 @@ const routerBase =
     ? {
         router: {
           base: '/medellinjs/',
+          extendRoutes(routes, resolve) {
+            routes.push({
+              name: 'custom',
+              path: '*',
+              component: resolve(__dirname, 'pages/index.vue'),
+            })
+          },
         },
       }
-    : {}
+    : {
+        router: {
+          extendRoutes(routes, resolve) {
+            routes.push({
+              name: 'custom',
+              path: '*',
+              component: resolve(__dirname, 'pages/index.vue'),
+            })
+          },
+        },
+      }
 
 export default {
   ssr: true,


### PR DESCRIPTION
# Show the main page when an invalid URL is searched.

Closes #534

## Overview

when you visit i.e medellinjs.org/campujs and error page is displayed.
With this fix, instead the error page, it should showed the main page.

## Preview URL
[Deploy preview 536](https://deploy-preview-536--medellinjs.netlify.com/)
