### PR TITLE
fix - markdown update issue #254

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,48 +9,48 @@ las contribuciones con valiosas.
 
 Esta guia explica el proceso para contribuir al repositorio Github `coljs/medellinjs.org` y describe que hacer en cad paso.
 
-## [Code of Conduct](./TODO/coc.md)
- 
-Medellinjs.org tiene un codigo de conducta [Code of Conduct](./TODO/coc.md) el cual *todos* los contribuidores deben seguir.
-Este codigo de conducta expresa el comportamiento *minimo* esperado por todos los contribuidores.
+## [Code of Conduct](./doc/general/coc.md)
 
-## [Issues](./TODO/issues.md)
+Medellinjs.org tiene un codigo de conducta [Code of Conduct](./doc/general/coc.md) el cual _todos_ los contribuidores deben seguir.
+Este codigo de conducta expresa el comportamiento _minimo_ esperado por todos los contribuidores.
+
+## [Issues](./doc/guides/contributing/issues.md)
 
 Issues en `coljs/medellinjs` es el lugar principal donde se reportan bugs y se realizan discusiones generales.
 
-* [Como Contribuir en Issues](./doc/guides/contributing/issues.md#how-to-contribute-in-issues)
-* [Asking for General Help](./doc/guides/contributing/issues.md#asking-for-general-help)
-* [Discusiones no tecnicas](./doc/guides/contributing/issues.md#discussing-non-technical-topics)
-* [Enviando un Bug](./doc/guides/contributing/issues.md#submitting-a-bug-report)
-* [Triaging a Bug Report](./doc/guides/contributing/issues.md#triaging-a-bug-report)
-* [Resolviendo un Bug](./doc/guides/contributing/issues.md#resolving-a-bug-report)
+- [Como Contribuir en Issues](./doc/guides/contributing/issues.md#hcomo-contribuir-en-issues)
+- [Asking for General Help](./doc/guides/contributing/issues.md#solicitando-ayuda-en-general)
+- [Discusiones no tecnicas](./doc/guides/contributing/issues.md#discusiones-no-tecnicas)
+- [Enviando un Bug](./doc/guides/contributing/issues.md#reportando-un-bug)
+- [Triaging a Bug Report](./doc/guides/contributing/issues.md#bug-triage)
+- [Resolviendo un Bug](./doc/guides/contributing/issues.md#resolviendo-un-bug)
 
-## [Pull Requests](./TODO/pull-requests.md)
+## [Pull Requests](./doc/guides/contributing/pull_request.md)
 
 Pull Requests son el camino concreto de los cambios hechos en el código, documentación en este repositorio.
 
-* [Setting up your local environment](./doc/guides/contributing/pull-requests.md#setting-up-your-local-environment)
+- [Setting up your local environment](./README.md#build-setup)
 
 <a id="developers-certificate-of-origin"></a>
+
 ## Certificado del desarrollador
 
 Para ser contribuidor de este projecto, yo certifico que:
 
-* (a) Las contribuiones son creadas en su todo ó en parte por mí y yo
+- (a) Las contribuiones son creadas en su todo ó en parte por mí y yo
   tengo los derechos para enviarlo bajo la licencia open source indicada
   en el archivo; o
 
-* (b) La contribución esta basada bajo un trabajo previo que, desde
+- (b) La contribución esta basada bajo un trabajo previo que, desde
   de mi conocimiento, es cubierto bajo una licencia open source apropiada
   y yo tengo los derechos bajo una licencia que permite enviarlo con modificaciones,
   aún cuando es creado completamente o parcialmente por mi, bajo el mismo
   licenciamiento open source (sin tener permitido compartirlo bajo un diferente licencia),
   como se indica en el archivo; o
-  
-* (c) La contribución fue provista directamente para mi por alguna otra persona
+- (c) La contribución fue provista directamente para mi por alguna otra persona
   quien se puede certificar (a), (b) o (c) i yo no lo modifique.
 
-* (d) Yo entiendo y acepto que este proyecto y las contribuciones son publicas
+- (d) Yo entiendo y acepto que este proyecto y las contribuciones son publicas
   y que son guardadas en las contribucion (incluyendo toda la información personal
   que envie con este, incluyendo my salida) is mantenida indefinidamente y puede ser redistribuida
   consistentemente con este projecto o la licencia open source envuelta.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,14 +18,15 @@ Este codigo de conducta expresa el comportamiento _minimo_ esperado por todos lo
 
 Issues en `coljs/medellinjs` es el lugar principal donde se reportan bugs y se realizan discusiones generales.
 
-- [Como Contribuir en Issues](./doc/guides/contributing/issues.md#hcomo-contribuir-en-issues)
+- [Como Contribuir en Issues](./doc/guides/contributing/issues.md#como-contribuir-en-issues)
 - [Asking for General Help](./doc/guides/contributing/issues.md#solicitando-ayuda-en-general)
 - [Discusiones no tecnicas](./doc/guides/contributing/issues.md#discusiones-no-tecnicas)
 - [Enviando un Bug](./doc/guides/contributing/issues.md#reportando-un-bug)
 - [Triaging a Bug Report](./doc/guides/contributing/issues.md#bug-triage)
 - [Resolviendo un Bug](./doc/guides/contributing/issues.md#resolviendo-un-bug)
 
-## [Pull Requests](./doc/guides/contributing/pull_request.md)
+## [Pull Requests](./doc/guides/contributing/pull_
+request.md)
 
 Pull Requests son el camino concreto de los cambios hechos en el código, documentación en este repositorio.
 

--- a/doc/general/coc.md
+++ b/doc/general/coc.md
@@ -1,0 +1,162 @@
+# [JavaScript MDE] - Código de Conducta
+
+## 1. Propósito
+
+Uno de los objetivos principales de `JavaScript Mde es ser inclusiva para el
+mayor número de contribuyentes, con la mayor diversidad de orígenes posibles.
+Como tal, estamos comprometidos a proporcionar un ambiente agradable, seguro y
+acogedor para todos, independientemente de su sexo, orientación sexual,
+capacidad, etnia, nivel socioeconómico, y religión (o falta de la misma).
+
+Este código de conducta resume nuestras expectativas para todos los que
+participan en nuestra comunidad, así como las consecuencias para el
+comportamiento inaceptable.
+
+Invitamos a todos los que participan en `colombia.dev` a que nos ayuden a crear
+experiencias seguras y positivas para todos.
+
+## 2. Ciudadanía de [Software / Cultura / Tecnología] Libre
+
+Un objetivo adicional de este Código de Conducta es aumentar la ciudadanía de
+[software / cultura / tecnología] libre mediante el fomento de los participantes
+a reconocer y fortalecer las relaciones entre nuestras acciones y sus efectos en
+nuestra comunidad.
+
+Las comunidades reflejan las sociedades en las que existen y la acción positiva
+es fundamental para contrarrestar las muchas formas de desigualdad y los abusos
+de poder que existen en la sociedad.
+
+Si ves a alguien que está haciendo un esfuerzo adicional y significativo para
+asegurar que nuestra comunidad sea acogedora, amable, y esta persona alienta a
+todos los participantes a que contribuyan en la mayor medida, nos gustaría saber.
+
+## 3. Comportamiento esperado
+
+- Participa de manera auténtica y activa. Al hacerlo, contribuyes a la salud y
+  la longevidad de esta comunidad.
+- Ejercita la consideración y el respeto en tus comunicaciones y acciones.
+- Intenta colaborar en lugar de generar conflicto.
+- Absténte de adoptar una conducta y un lenguaje degradantes, discriminatorios,
+  abusivos o acosadores.
+- Sé consciente de tu entorno y de tus compañeros participantes. Alerta a
+  líderes de la comunidad si notas una situación peligrosa, alguien en apuros, o
+  violaciones de este Código de Conducta, incluso si parecen intrascendentes.
+
+## 4. Comportamiento inaceptable
+
+Comportamientos inaceptables incluyen: intimidación, acoso, abuso,
+discriminación, comunicación despectiva o degradante o acciones por cualquier
+participante en nuestra comunidad ya sea en internet, en todos los eventos
+relacionados y en las comunicaciones uno-a-uno que se realizan en el contexto de
+los negocios de la comunidad. Es posible que los lugares para eventos
+comunitarios sean de uso compartido con los miembros del público; por favor ser
+respetuoso con todos aquellos que los frecuentan.
+
+El acoso incluye: comentarios nocivos o perjudiciales, verbales o escritos
+relacionados con el género, la orientación sexual, raza, religión, discapacidad;
+uso inadecuado de desnudos y / o imágenes sexuales en espacios públicos
+(incluyendo la presentación diapositivas); intimidación deliberada, acecho o
+seguimiento; fotografías o grabaciones acosadoras; interrupción sostenida de
+charlas y otros eventos; contacto físico inapropiado, y atención sexual no
+deseada.
+
+## 5. Consecuencias de comportamiento inaceptable
+
+El comportamiento inaceptable de cualquier miembro de la comunidad, incluyendo
+patrocinadores y aquellos con poder de decisión, no será tolerado.
+
+Se espera que personas a quienes se les solicite que detengan su comportamiento
+inaceptable lo hagan de manera inmediata.
+
+Si un miembro de la comunidad participa en una conducta inaceptable, los
+organizadores comunitarios pueden tomar cualquier acción que consideren
+apropiada, hasta e incluyendo una prohibición temporal o expulsión permanente
+de la comunidad, sin previo aviso (y sin derecho a reembolso en el caso de un
+evento de pago).
+
+## 6. Si usted es testigo o es objeto de comportamiento inaceptable
+
+Si eres víctima o testigo de una conducta inaceptable, o tienes cualquier
+inquietud, por favor comunícate con un organizador del meetup lo antes posible.
+
+Email: TODO
+
+Adicionalmente, los organizadores comunitarios están disponibles para ayudar
+a miembros de la comunidad a contactar a la policía local o interceder para que
+víctimas de comportamiento inaceptable se sientan seguros,
+En el contexto de los eventos en persona, los organizadores
+también pueden proporcionar escoltas si un miembro de la comunidad lo siente
+necesario.
+
+## 7. Políticas de moderación
+
+Estas son las políticas para mantener los estándares de conducta en nuestra
+comunidad en los canales de chat, meetups asociados, conferencias,
+grupos de estudio, y eventos virtuales.
+
+- Palabras que violen las normas de Código de Conducta, incluyendo comentarios
+  odiosos, hirientes, opresivos, o excluyentes, no están permitidos. (Se
+  permite las "malas palabras", pero nunca enfocadas hacia otro
+  usuario/asistente, y nunca de una manera odiosa.)
+- Comentarios que los organizadores encuentran inapropiados tampoco están
+  permitidos, así aparezcan en el código de conducta o no.
+- Los organizadores primero deberán responder a dichos comentarios con una
+  advertencia.
+- Si la advertencia es ignorada, el usuario/asistente será expulsado del canal
+  para que evalúe su comportamiento, o deberá retirarse del lugar por 30
+  minutos en caso de eventos presenciales.
+- Si el usuario/asistente regresa y continúa causando problemas, será
+  expulsado del grupo/evento/lugar/Slack de forma indefinida.
+- Los organizadores pueden retractar la expulsión a su discreción si esta se
+  trata de una primera infracción y se ha ofrecido una disculpa sincera a
+  quien ofendieron.
+- Si un organizador expulsa a alguien y usted cree que fue una expulsión sin
+  causa, contacte a ese organizador, o a un organizador diferente
+  **en privado**. Quejas sobre expulsiones en medios abiertos, sociales, u
+  otros canales no son permitidas y conllevaran a más expulsiones.
+- Los organizadores se rigen por un nivel más alto que otros miembros de la
+  comunidad. Si un organizador crea una situación inadecuada, este será
+  juzgado con un estándar más alto.
+
+En la comunidad `colombia.dev` nos esforzamos por ir un paso más allá y cuidar
+el uno del otro. No se limite a tratar de mostrar su excelencia técnica, trate
+también de ser la mejor persona posible. En particular, evite tocar temas
+ofensivos o sensibles, especialmente si están fuera del tema tratado; esto muy a
+menudo conduce a peleas innecesarias, sentimientos heridos, y a daños en la
+confianza; peor aún, puede conducir a que personas se alejen de la comunidad en
+su totalidad.
+
+De la misma forma, si alguien está en desacuerdo con algo que usted dijo o hizo,
+resista el impulso de estar a la defensiva. Simplemente pare de hacer o decir lo
+que fuera que causó la queja y pida disculpas. Hay buenas probabilidades de que
+usted se pudo haber comunicado mejor, incluso si usted siente que fue
+malinterpretado o injustamente acusado, - recuerde que es su responsabilidad
+hacer que sus compañeras y compañeros de `colombia.dev` estén cómodos.
+
+Todo el mundo busca harmonía y todos estamos aquí, ante todo, porque queremos
+hablar de tecnologías que nos gustan. Por lo general, la gente está dispuesta a
+asumir buenas intenciones y perdonar, siempre y cuando usted gane su confianza y
+actúe de forma honrada.
+
+[Adaptado de la Política de Moderación de Rust](https://github.com/rust-lang/rust/wiki/Note-development-policy#moderation)
+
+## 8. Alcance
+
+Esperamos que todos los participantes de la comunidad (contribuyentes, pagados o
+de otro modo; patrocinadores; y otros invitados) se atengan a este Código de
+Conducta en todos los espacios virtuales y presenciales, así como en todas las
+comunicaciones de uno-a-uno pertinentes a los negocios de la comunidad.
+
+## 9. Contacto
+
+- TODO
+- TODO
+
+## 10. Licencia y atribución
+
+Basado en el [Codigo de Conducta de
+Colombia-Dev](https://github.com/colombia-dev/codigo-de-conducta)
+
+Este Código de Conducta se distribuye bajo una licencia [Creative Commons – ShareAlike (BY-SA)](http://creativecommons.org/licenses/by-sa/3.0/)
+
+Adaptado del [Código de Conducta de Stumptown Syndicate](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md)

--- a/doc/guides/contributing/issues.md
+++ b/doc/guides/contributing/issues.md
@@ -1,0 +1,23 @@
+### Cómo contribuir en Issues
+
+TODO
+
+### Solicitando ayuda en general
+
+TODO
+
+### Discusiones no técnicas
+
+TODO
+
+### Reportando un Bug
+
+TODO
+
+### Bug Triage
+
+TODO
+
+### Resolviendo un Bug
+
+TODO

--- a/doc/guides/contributing/pull_request.md
+++ b/doc/guides/contributing/pull_request.md
@@ -1,0 +1,1 @@
+### Pull Request


### PR DESCRIPTION
# Arreglar links en el CONTRIBUTING.md

Closes #254

## Overview

Los links del CONTRIBUTING.md estaban rotos, cree un par de archivos y agregué algo de contenido al del código de conducta, que es del único que tengo un poco de contexto.

## Preview URL
[Deploy preview ###](https://deploy-preview-###--medellinjs.netlify.com/)

*Please change the ### for the number of the `pull request`, after that you can delete this line*.
